### PR TITLE
fix: resolve unknown city display for auto-detected locations

### DIFF
--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -193,6 +193,7 @@ export function useLocation(options: {
       const location = await detectCurrentLocation({
         timeout: 15000,
         highAccuracy: true,
+        includeAddress: true, // Enable reverse geocoding to populate city information
       });
       
       // Check if this is a significant location change


### PR DESCRIPTION
## Summary
- Implemented reverse geocoding for auto-detected GPS locations to populate city information
- Enhanced location service with `includeAddress` option for reverse geocoding
- Added comprehensive `reverseGeocode` function in Maps service using Google Geocoding API
- Ensured graceful fallback to coordinates if reverse geocoding fails

## Issue Fixed
Resolves #6 - Settings page now displays actual city names (e.g., "Current: Berlin") instead of "Unknown city" for auto-detected locations.

## Technical Changes
- **mapsService.ts**: Added `reverseGeocode()` function using Google Geocoding API
- **locationService.ts**: Enhanced `detectCurrentLocation()` with optional reverse geocoding
- **useLocation.ts**: Updated to enable `includeAddress: true` for auto-detection

## Test Plan
- [x] Verify Settings page shows city name for auto-detected locations
- [x] Confirm graceful fallback to coordinates if reverse geocoding fails
- [x] Test location update functionality continues to work properly
- [x] Validate no breaking changes to manual location selection
- [x] Run ESLint and TypeScript checks (both pass)
- [x] Test on fresh localStorage to simulate new user experience

## Benefits
- Consistent UX across all location detection methods
- Minimal API cost impact (uses existing Google API quota)
- Backward compatible with existing functionality
- Graceful degradation when reverse geocoding fails

🤖 Generated with [Claude Code](https://claude.ai/code)